### PR TITLE
Releasing next version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ env:
 jobs:
   CallCI:
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   ReleaseDryRun:
     runs-on: ubuntu-latest

--- a/.semrelease/this_release
+++ b/.semrelease/this_release
@@ -3,3 +3,4 @@
 #   git log origin..HEAD | grep "^\s" > .semrelease/this_release
 - Fix(323): Dark/Light mode not working properly.
 - Dep(GH): Bump actions/checkout from 4 to 5.
+- Fix(GHA): Pass secrets from workflow `release` to `ci`.

--- a/content/Bat/.github/workflows/ci.yaml
+++ b/content/Bat/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           platform: ${{ matrix.platforms }}
-          registry: test
+          registry: docker.io
           image: test
           tags: test
           pushImage: false

--- a/content/Bat/.github/workflows/release.yaml
+++ b/content/Bat/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   CallCI:
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   ReleaseDryRun:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Fix(323): Dark/Light mode not working properly.
- Dep(GH): Bump actions/checkout from 4 to 5.
- Fix(GHA): Pass secrets from workflow `release` to `ci`.
